### PR TITLE
Use carmine to talk to redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+.lein-*
+.nrepl-*
+/target/

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Redis backed Caching and Memoization, following `core.cache` and `core.memoize`.
 ### Installing
 -------
 Add the following to the `:dependencies` vector of your `project.clj` file:
-[![clojars version](https://clojars.org/crache/latest-version.svg?raw=true)]
-(https://clojars.org/crache)
+[![clojars version][1]][2]
 
 ## Usage
 -------
@@ -24,16 +23,27 @@ Awesome! :)
 ```clj
 => (require '[crache.memo :refer [memo-redis]])
 ```
+
+[Redis client connection specification][3]:
+
 ```clj
-; redis memoizes 'f', binding the client to localhost:6379 address of the redis server
-=> (def memo-f (memo-redis f))
+(def conn {:pool {} :spec {:host "localhost" :port 6379}})
 ```
+
+```clj
+; redis memoizes 'f', using a key-prefix
+=> (def memo-f (memo-redis f conn (str ::f)))
+```
+
 or
+
 ```clj
-; redis memoizes 'f', binding the client to myapp.provider.com:6300 address of the redis server
-=> (def memo-f (memo-redis f :host "myapp.provider.com" :port 6300))
+; redis memoizes 'f', using a key-prefix and an expire time (60 seconds)
+=> (def memo-f (memo-redis f conn (str ::f) 60))
 ```
+
 then use `memo-f` like you would use your usual memoized fn:
+
 ```clj
 => (memo-f some-input) ;=> some-output
 ```
@@ -43,3 +53,7 @@ then use `memo-f` like you would use your usual memoized fn:
 Copyright (C) 2014 Homer Strong
 
 Distributed under the Eclipse Public License, the same as Clojure.
+
+[1]: https://clojars.org/crache/latest-version.svg?raw=true
+[2]: https://clojars.org/crache
+[3]: https://github.com/ptaoussanis/carmine#connections

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :license {:name "Eclipse Public License" :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "http://github.com/strongh/crache"
   :dependencies [[org.clojure/clojure "1.4.0"]
+                 [com.taoensso/carmine "2.7.0"]
                  [org.clojure/core.cache "0.6.4"]
-                 [org.clojure/core.memoize "0.5.1"]
-                 [org.clojars.strongh/clj-redis "0.0.20"]])
+                 [org.clojure/core.memoize "0.5.6"]])

--- a/src/crache/cache.clj
+++ b/src/crache/cache.clj
@@ -1,138 +1,42 @@
 (ns crache.cache
-  (:require [clj-redis.client :as redis]
+  (:require [taoensso.carmine :as car]
             [clojure.core.cache :as cache]))
 
-(def CHARS
-     (map char (concat (range 48 58)
-                       (range 66 91)
-                       (range 97 123))))
+(defmacro wcar* [$ & body]
+  `(car/wcar (:conn ~$) ~@body))
 
-(defn gen-rand-str
-  []
-  (apply
-   str
-   (take 20 (repeatedly #(rand-nth CHARS)))))
-
-(defn read-redis-str
-  ([r kp item]
-     (read-redis-str r kp item nil))
-  ([r kp item not-found]
-     (if-let [item-str (redis/get r (str kp (pr-str item)))]
-       (read-string item-str)
-       not-found)))
+(defn key-for [$ item]
+  (str (:key-prefix $) ":" (pr-str item)))
 
 (cache/defcache RedisCache [$]
   cache/CacheProtocol
   (lookup [_ item]
-          (if (:delay $)
-            (delay (read-redis-str
-                    (:redis-connection $)
-                    (:key-prefix $)
-                    item))
-            (read-redis-str
-             (:redis-connection $)
-             (:key-prefix $)
-             item)))
+    (delay (wcar* $ (car/get (key-for $ item)))))
 
   (lookup [_ item not-found]
-          (if (:delay $)
-            (delay (read-redis-str
-                    (:redis-connection $)
-                    (:key-prefix $)
-                    item not-found))
-            (read-redis-str
-             (:redis-connection $)
-             (:key-prefix $)
-             item not-found)))
+    (delay (or (wcar* $ (car/get (key-for $ item))) not-found)))
   
   (has? [_ item]
-        (redis/exists (:redis-connection $) (str (:key-prefix $) (pr-str item))))
+    (= 1 (wcar* $ (car/exists (key-for $ item)))))
   
   (hit [_ item]
-       (RedisCache. $))
+    (RedisCache. $))
   
   (miss [_ item val]
-        (redis/set (:redis-connection $)
-                   (str (:key-prefix $) (pr-str item))
-                   (pr-str (if (delay? val) @val val)))
-        (RedisCache. $))
+    (let [args (when-let [t (:ttl $)] ["ex" t])]
+      (wcar* $ (apply car/set (key-for $ item) (car/serialize @val) args)))
+    (RedisCache. $))
   
   (evict [_ item]
-         (redis/del (:redis-connection $) (str (:key-prefix $) (pr-str item)))
-         (RedisCache. $))
+    (wcar* $ (car/del (key-for $ item)))
+    (RedisCache. $))
   
   (seed [_ base]
-        (RedisCache.
-         {:key-prefix (:key-prefix base (gen-rand-str))
-          :delay (:delay base)
-          :redis-connection (redis/init {:url (str "redis://" (:host base)
-                                                   ":" (:port base))})}))
+    (RedisCache. base))
+
   Object
   (toString [_] (str $)))
-
-
-(cache/defcache RedisTTLCache [$]
-  cache/CacheProtocol
-  (lookup [_ item]
-          (if (:delay $)
-            (delay (read-redis-str
-                    (:redis-connection $)
-                    (:key-prefix $)
-                    item))
-            (read-redis-str
-             (:redis-connection $)
-             (:key-prefix $)
-             item)))
-
-  (lookup [_ item not-found]
-          (if (:delay $)
-            (delay (read-redis-str
-                    (:redis-connection $)
-                    (:key-prefix $)
-                    item not-found))
-            (read-redis-str
-             (:redis-connection $)
-             (:key-prefix $)
-             item not-found)))
-  
-  (has? [_ item]
-        (redis/exists (:redis-connection $) (str (:key-prefix $) (pr-str item))))
-  
-  (hit [_ item]
-       (RedisTTLCache. $))
-  
-  (miss [_ item val]
-        (let [redis-connection (:redis-connection $)
-              redis-key (str (:key-prefix $) (pr-str item))]
-          (redis/set redis-connection redis-key (pr-str (if (delay? val) @val val)))
-          (redis/expire redis-connection redis-key (:ttl $))
-          (RedisTTLCache. $)))
-  
-  (evict [_ item]
-         (redis/del (:redis-connection $) (str (:key-prefix $) (pr-str item)))
-         (RedisTTLCache. $))
-  
-  (seed [_ base]
-        (RedisTTLCache.
-         {:key-prefix (:key-prefix base (gen-rand-str))
-          :delay (:delay base)
-          :ttl (long (:ttl base))
-          :redis-connection (redis/init {:url (str "redis://" (:host base)
-                                                   ":" (:port base))})}))
-  Object
-  (toString [_] (str $)))
-
 
 (defn redis-cache-factory
-  [& {:keys [host port delay key-prefix]
-      :or {host "localhost"
-           port 6379}}]
-  (cache/seed (RedisCache. {}) {:host host :port port
-                                :delay delay :key-prefix key-prefix}))
-
-(defn redis-ttl-cache-factory
-  [ttl & {:keys [host port delay key-prefix]
-          :or {host "localhost"
-               port 6379}}]
-  (cache/seed (RedisTTLCache. {}) {:host host :port port
-                                   :delay delay :ttl ttl :key-prefix key-prefix}))
+  [conn key-prefix & [ttl]]
+  (cache/seed (RedisCache. {}) {:conn conn :key-prefix key-prefix :ttl ttl}))

--- a/src/crache/memo.clj
+++ b/src/crache/memo.clj
@@ -1,24 +1,12 @@
 (ns crache.memo
   (:import [clojure.core.memoize.PluggableMemoization])
-  (:use [crache.cache :only [redis-cache-factory redis-ttl-cache-factory]]
+  (:use [crache.cache :only [redis-cache-factory]]
         [clojure.core.memoize :only [build-memoizer]]))
 
 
 (defn memo-redis
-  [f & {:keys [host port key-prefix]
-        :or {host "localhost"
-             port 6379}}]
+  [f conn key-prefix & [ttl]]
   (build-memoizer
    #(clojure.core.memoize.PluggableMemoization.
-     %1 (redis-cache-factory :host host :port port :delay true :key-prefix key-prefix))
-   f))
-
-(defn memo-ttl-redis
-  [f ttl & {:keys [host port key-prefix]
-            :or {host "localhost"
-                 port 6379}}]
-  (build-memoizer
-   #(clojure.core.memoize.PluggableMemoization.
-     %1 (redis-ttl-cache-factory ttl :host host :port port
-                                 :delay true :key-prefix key-prefix))
+     %1 (apply redis-cache-factory conn key-prefix (when ttl [ttl])))
    f))


### PR DESCRIPTION
- Replaces clj-redis with the carmine redis client library.
- Removes separate ttl memoize cache. The ttl is now an optional
  constructor parameter.
- Removes the non-delay case, as core.memoize will always use delays.
- Uses the redis EX option to SET instead of performing SET and
  EXPIRE in separate commands (race condition).
