### PR TITLE
Fix 'cache/miss' missing 'delay?'

### DIFF
--- a/src/crache/cache.clj
+++ b/src/crache/cache.clj
@@ -23,8 +23,9 @@
     (RedisCache. $))
   
   (miss [_ item val]
-    (let [args (when-let [t (:ttl $)] ["ex" t])]
-      (wcar* $ (apply car/set (key-for $ item) (car/serialize @val) args)))
+    (let [args (when-let [t (:ttl $)] ["ex" t])
+          val (if (delay? val) @val val)]
+      (wcar* $ (apply car/set (key-for $ item) (car/serialize val) args)))
     (RedisCache. $))
   
   (evict [_ item]


### PR DESCRIPTION
I don't understand the logic behind `miss` being responsible for checking if an item's value is delayed. Anyway this fixes the missing check.
